### PR TITLE
fix: resolve relative baseUrl in buildUrl

### DIFF
--- a/src/internals/url-helpers.ts
+++ b/src/internals/url-helpers.ts
@@ -21,14 +21,23 @@ export function buildUrl({ baseUrl, path, query }: UrlParts): URL {
     throw new Error("Base URL is required for building the request URL.");
   }
 
-  // 2. URL을 생성합니다.
-  const url = !path 
-    ? new URL(baseUrl)
-    : new URL(baseUrl.endsWith('/') && path.startsWith('/')
-      ? baseUrl + path.slice(1)
-      : baseUrl + path);
+  // 2. 상대 경로인 경우 origin을 자동으로 추가합니다.
+  let resolvedBase = baseUrl;
+  if (!baseUrl.startsWith('http://') && !baseUrl.startsWith('https://')) {
+    const origin = typeof globalThis !== 'undefined' && typeof (globalThis as any).location !== 'undefined'
+      ? (globalThis as any).location.origin
+      : '';
+    resolvedBase = origin + baseUrl;
+  }
 
-  // 3. 쿼리 파라미터를 추가합니다.
+  // 3. URL을 생성합니다.
+  const url = !path
+    ? new URL(resolvedBase)
+    : new URL(resolvedBase.endsWith('/') && path.startsWith('/')
+      ? resolvedBase + path.slice(1)
+      : resolvedBase + path);
+
+  // 4. 쿼리 파라미터를 추가합니다.
   if (query) {
     Object.entries(query).forEach(([key, value]) => {
       if (value !== null && value !== undefined) {


### PR DESCRIPTION
## Summary
- `buildUrl`에서 상대 경로 `baseUrl` (예: `/api`) 사용 시 `Invalid URL` 에러 발생하는 버그 수정
- 상대 경로인 경우 `location.origin`을 자동으로 prepend하여 유효한 절대 URL 생성
- SSR 환경(location 없음)에서는 빈 문자열로 fallback

## Changes
`src/internals/url-helpers.ts` — `buildUrl` 함수에 상대 경로 감지 및 origin 자동 추가 로직 삽입

## Test Plan
- [x] `new HttpClient({ baseUrl: '/api' })` → 브라우저에서 정상 동작 확인
- [ ] 기존 절대 URL `baseUrl` 동작 변경 없음 확인

Closes #1