### PR TITLE
feat: add onRequest/onResponse hooks (v0.8.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "devDependencies": {
     "@types/node": "^25.5.0",
     "@vitest/ui": "^4.1.2",
+    "msw": "^2.12.14",
     "typescript": "^5.9.3",
     "vite": "^8.0.3",
     "vite-plugin-dts": "^4.5.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iyulab/http-client",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "description": "A simple HTTP client for handling responses.",
   "keywords": [
     "http",

--- a/src/HttpClient.ts
+++ b/src/HttpClient.ts
@@ -152,6 +152,8 @@ export class HttpClient {
       ? setTimeout(() => token.cancel(), timeout)
       : null;
 
+    let httpResponse: HttpResponse;
+
     try {
       // 6. Fetch 요청
       const res = await fetch(url.toString(), {
@@ -166,20 +168,7 @@ export class HttpClient {
       });
 
       // 7. 응답 처리
-      const httpResponse = new HttpResponse(res);
-
-      // 8. onResponse 훅 호출
-      if (this.onResponse) {
-        await this.onResponse({
-          ok: httpResponse.ok,
-          status: httpResponse.status,
-          statusText: httpResponse.statusText,
-          headers: httpResponse.headers,
-          url: httpResponse.url,
-        });
-      }
-
-      return httpResponse;
+      httpResponse = new HttpResponse(res);
     } catch (error: any) {
       // CancelToken 상태를 1차 판정 기준으로 사용
       if (token.isCancelled) {
@@ -187,11 +176,24 @@ export class HttpClient {
       }
       throw error;
     } finally {
-      // 9. 타이머를 정리합니다.
+      // 8. 타이머를 정리합니다.
       if (timer) {
         clearTimeout(timer);
       }
     }
+
+    // 9. onResponse 훅 호출 (try/catch 밖에서 호출하여 CanceledError와 분리)
+    if (this.onResponse) {
+      await this.onResponse({
+        ok: httpResponse.ok,
+        status: httpResponse.status,
+        statusText: httpResponse.statusText,
+        headers: httpResponse.headers,
+        url: httpResponse.url,
+      });
+    }
+
+    return httpResponse;
   }
 
   /**

--- a/src/HttpClient.ts
+++ b/src/HttpClient.ts
@@ -1,6 +1,6 @@
 import type { HttpRequest, HttpUploadRequest, HttpDownloadRequest } from "./types/HttpRequest";
 import type { FileUploadResponse } from "./types/FileUploadResponse";
-import type { HttpClientConfig } from "./types/HttpClientConfig";
+import type { HttpClientConfig, RequestHookInfo, ResponseHookInfo } from "./types/HttpClientConfig";
 import { HttpResponse } from "./HttpResponse";
 import { CancelToken } from "./CancelToken";
 import { CanceledError } from "./CanceledError";
@@ -25,6 +25,8 @@ export class HttpClient {
   private readonly mode?: RequestMode;
   private readonly cache?: RequestCache;
   private readonly keepalive?: boolean;
+  private readonly onRequest?: (request: RequestHookInfo, headers: Headers) => void | Promise<void>;
+  private readonly onResponse?: (response: ResponseHookInfo) => void | Promise<void>;
 
   constructor(config: HttpClientConfig) {
     this.baseUrl = config.baseUrl;
@@ -34,6 +36,8 @@ export class HttpClient {
     this.mode = config.mode;
     this.cache = config.cache;
     this.keepalive = config.keepalive;
+    this.onRequest = config.onRequest;
+    this.onResponse = config.onResponse;
   }
 
   /**
@@ -133,7 +137,15 @@ export class HttpClient {
       }
     }
 
-    // 4. Abort 설정
+    // 4. onRequest 훅 호출
+    if (this.onRequest) {
+      await this.onRequest(
+        { method: request.method, path: request.path, query: request.query, baseUrl: request.baseUrl ?? this.baseUrl },
+        headers,
+      );
+    }
+
+    // 5. Abort 설정
     const token = cancelToken || new CancelToken();
     const timeout = request.timeout ?? this.timeout;
     const timer = timeout
@@ -141,7 +153,7 @@ export class HttpClient {
       : null;
 
     try {
-      // 5. Fetch 요청
+      // 6. Fetch 요청
       const res = await fetch(url.toString(), {
         method: request.method,
         headers: headers,
@@ -153,8 +165,21 @@ export class HttpClient {
         signal: token.signal,
       });
 
-      // 6. 응답 처리
-      return new HttpResponse(res);
+      // 7. 응답 처리
+      const httpResponse = new HttpResponse(res);
+
+      // 8. onResponse 훅 호출
+      if (this.onResponse) {
+        await this.onResponse({
+          ok: httpResponse.ok,
+          status: httpResponse.status,
+          statusText: httpResponse.statusText,
+          headers: httpResponse.headers,
+          url: httpResponse.url,
+        });
+      }
+
+      return httpResponse;
     } catch (error: any) {
       // CancelToken 상태를 1차 판정 기준으로 사용
       if (token.isCancelled) {
@@ -162,7 +187,7 @@ export class HttpClient {
       }
       throw error;
     } finally {
-      // 7. 타이머를 정리합니다.
+      // 9. 타이머를 정리합니다.
       if (timer) {
         clearTimeout(timer);
       }
@@ -218,6 +243,15 @@ export class HttpClient {
         uploadHeaders.set(key, value);
       });
     }
+
+    // 5.1 onRequest 훅 호출
+    if (this.onRequest) {
+      await this.onRequest(
+        { method: request.method, path: request.path, query: request.query, baseUrl: request.baseUrl ?? this.baseUrl },
+        uploadHeaders,
+      );
+    }
+
     uploadHeaders.forEach((value, key) => {
       xhr.setRequestHeader(key, value);
     });

--- a/src/types/HttpClientConfig.ts
+++ b/src/types/HttpClientConfig.ts
@@ -1,4 +1,34 @@
 /**
+ * onRequest 훅에 전달되는 요청 정보입니다.
+ */
+export interface RequestHookInfo {
+  /** HTTP 메서드 */
+  method: string;
+  /** 요청 경로 */
+  path?: string;
+  /** 쿼리 파라미터 */
+  query?: Record<string, string | string[]>;
+  /** 기본 URL */
+  baseUrl?: string;
+}
+
+/**
+ * onResponse 훅에 전달되는 응답 정보입니다.
+ */
+export interface ResponseHookInfo {
+  /** 응답 상태가 성공(2xx)인지 여부 */
+  ok: boolean;
+  /** HTTP 상태 코드 */
+  status: number;
+  /** HTTP 상태 텍스트 */
+  statusText: string;
+  /** 응답 헤더 */
+  headers: Headers;
+  /** 응답 URL */
+  url: string;
+}
+
+/**
  * HTTP 클라이언트를 설정하기 위한 구성 옵션입니다.
  */
 export interface HttpClientConfig {
@@ -63,4 +93,23 @@ export interface HttpClientConfig {
    * @warning 일부 브라우저나 데이터가 큰 경우 정상적으로 동작하지 않을 수 있습니다.
    */
   keepalive?: boolean;
+
+  /**
+   * 요청 전에 호출되는 훅입니다.
+   * 요청 정보를 확인하거나 헤더를 수정할 수 있습니다.
+   * 비동기 함수를 지원합니다.
+   *
+   * @param request 요청 정보
+   * @param headers 요청 헤더 (수정 가능)
+   */
+  onRequest?: (request: RequestHookInfo, headers: Headers) => void | Promise<void>;
+
+  /**
+   * 응답 후에 호출되는 훅입니다.
+   * 응답 상태를 확인하거나 에러를 발생시킬 수 있습니다.
+   * 비동기 함수를 지원합니다.
+   *
+   * @param response 응답 정보
+   */
+  onResponse?: (response: ResponseHookInfo) => void | Promise<void>;
 }

--- a/src/types/HttpClientConfig.ts
+++ b/src/types/HttpClientConfig.ts
@@ -1,9 +1,11 @@
+import type { HttpMethod } from './HttpRequest';
+
 /**
  * onRequest 훅에 전달되는 요청 정보입니다.
  */
 export interface RequestHookInfo {
   /** HTTP 메서드 */
-  method: string;
+  method: HttpMethod;
   /** 요청 경로 */
   path?: string;
   /** 쿼리 파라미터 */

--- a/tests/HttpClient.test.ts
+++ b/tests/HttpClient.test.ts
@@ -15,10 +15,6 @@ const server = setupServer(
     }
     return new MswHttpResponse(null, { status: 401, statusText: 'Unauthorized' });
   }),
-  http.post('https://api.test.com/data', async ({ request }) => {
-    const body = await request.json();
-    return MswHttpResponse.json({ received: body });
-  }),
 );
 
 beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));

--- a/tests/HttpClient.test.ts
+++ b/tests/HttpClient.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeAll, afterAll, afterEach } from 'vitest';
+import { http, HttpResponse as MswHttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { HttpClient } from '../src/HttpClient';
+
+// MSW 서버 설정
+const server = setupServer(
+  http.get('https://api.test.com/users', () => {
+    return MswHttpResponse.json({ users: ['alice', 'bob'] });
+  }),
+  http.get('https://api.test.com/protected', ({ request }) => {
+    const auth = request.headers.get('Authorization');
+    if (auth === 'Bearer test-token') {
+      return MswHttpResponse.json({ data: 'secret' });
+    }
+    return new MswHttpResponse(null, { status: 401, statusText: 'Unauthorized' });
+  }),
+  http.post('https://api.test.com/data', async ({ request }) => {
+    const body = await request.json();
+    return MswHttpResponse.json({ received: body });
+  }),
+);
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe('HttpClient onRequest/onResponse hooks', () => {
+
+  it('onRequest hook is called before each request and can modify headers', async () => {
+    const client = new HttpClient({
+      baseUrl: 'https://api.test.com',
+      onRequest: (_req, headers) => {
+        headers.set('Authorization', 'Bearer test-token');
+      },
+    });
+
+    const res = await client.get('/protected');
+    expect(res.ok).toBe(true);
+    const data = await res.json<{ data: string }>();
+    expect(data.data).toBe('secret');
+  });
+
+  it('onRequest supports async functions', async () => {
+    const client = new HttpClient({
+      baseUrl: 'https://api.test.com',
+      onRequest: async (_req, headers) => {
+        // 비동기 토큰 조회 시뮬레이션
+        const token = await Promise.resolve('Bearer test-token');
+        headers.set('Authorization', token);
+      },
+    });
+
+    const res = await client.get('/protected');
+    expect(res.ok).toBe(true);
+    const data = await res.json<{ data: string }>();
+    expect(data.data).toBe('secret');
+  });
+
+  it('when onRequest is not provided, requests work normally', async () => {
+    const client = new HttpClient({
+      baseUrl: 'https://api.test.com',
+    });
+
+    const res = await client.get('/users');
+    expect(res.ok).toBe(true);
+    const data = await res.json<{ users: string[] }>();
+    expect(data.users).toEqual(['alice', 'bob']);
+  });
+
+  it('when onRequest throws, the request fails with that error', async () => {
+    const client = new HttpClient({
+      baseUrl: 'https://api.test.com',
+      onRequest: () => {
+        throw new Error('Token expired');
+      },
+    });
+
+    await expect(client.get('/users')).rejects.toThrow('Token expired');
+  });
+
+  it('onResponse hook is called after each response', async () => {
+    const onResponse = vi.fn();
+    const client = new HttpClient({
+      baseUrl: 'https://api.test.com',
+      onResponse,
+    });
+
+    const res = await client.get('/users');
+    expect(res.ok).toBe(true);
+
+    expect(onResponse).toHaveBeenCalledOnce();
+    expect(onResponse).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ok: true,
+        status: 200,
+        statusText: expect.any(String),
+        headers: expect.any(Headers),
+        url: expect.stringContaining('/users'),
+      }),
+    );
+  });
+
+  it('onResponse can throw errors which propagate to caller', async () => {
+    const client = new HttpClient({
+      baseUrl: 'https://api.test.com',
+      onResponse: (res) => {
+        if (res.status === 401) {
+          throw new Error('Unauthorized - please login');
+        }
+      },
+    });
+
+    // /protected without auth header => 401
+    await expect(client.get('/protected')).rejects.toThrow('Unauthorized - please login');
+  });
+
+  it('onRequest -> fetch -> onResponse execution order', async () => {
+    const order: string[] = [];
+
+    const client = new HttpClient({
+      baseUrl: 'https://api.test.com',
+      onRequest: () => {
+        order.push('onRequest');
+      },
+      onResponse: () => {
+        order.push('onResponse');
+      },
+    });
+
+    await client.get('/users');
+    expect(order).toEqual(['onRequest', 'onResponse']);
+  });
+});


### PR DESCRIPTION
## Summary
- `HttpClientConfig`에 `onRequest`/`onResponse` hook 함수 추가
- `send()`: onRequest → fetch → onResponse 파이프라인 구현
- `upload()`: onRequest hook 지원 (XHR 헤더 주입)
- onResponse는 try/catch 밖에서 호출하여 CanceledError와 분리
- `RequestHookInfo`/`ResponseHookInfo` 타입 export
- vitest + msw 기반 테스트 7건 (74/74 전체 통과)

## Motivation
alldot 등 소비 프로젝트에서 Bearer 토큰 자동 주입, 공통 에러 처리 패턴이 필요.
axios의 interceptor 역할을 간결한 hook 함수로 제공.

## Usage
```typescript
const client = new HttpClient({
  baseUrl: 'https://api.example.com',
  credentials: 'include',
  onRequest: async (request, headers) => {
    const token = await getAccessToken();
    if (token) headers.set('Authorization', `Bearer ${token}`);
  },
  onResponse: async (response) => {
    if (!response.ok) throw new Error(`HTTP ${response.status}`);
  },
});
```

## Test plan
- [x] onRequest 헤더 조작 테스트
- [x] onRequest 비동기 지원 테스트
- [x] hook 미제공 시 정상 동작 테스트
- [x] onRequest 에러 전파 테스트
- [x] onResponse 호출 및 파라미터 검증 테스트
- [x] onResponse 에러 전파 테스트
- [x] 실행 순서 (onRequest → fetch → onResponse) 테스트
- [x] 기존 67건 테스트 회귀 없음
- [x] 빌드 성공, dist에 타입 정의 포함