### PR TITLE
fix: accept HeadersInit for per-request headers and fix merge bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- `HttpClient.send()` per-request `headers` merge used `Headers.forEach(([key, value]) => ...)`, which destructured the first callback argument (`value: string`) as if it were an entries-tuple — silently corrupting header keys/values when per-request headers were provided. Replaced with the correct `(value, key) => ...` callback, mirroring the upload path.
+
+### Changed
+- **Reverted breaking narrowing from 0.8.0:** `HttpRequest.headers` is now `HeadersInit` again (matching `HttpClientConfig.headers`). Plain objects, `Headers` instances, and `[string, string][]` tuples are all accepted, and the client normalizes internally. Restoring this resolves the inconsistency between instance-level (`HeadersInit`) and per-request (`Headers`) headers without sacrificing any safety — `new Headers(init)` already validates the input.
+
 ## [0.8.0] - 2026-04-03
 
 ### Added

--- a/src/HttpClient.ts
+++ b/src/HttpClient.ts
@@ -108,9 +108,11 @@ export class HttpClient {
 
     // 2. Headers 설정 (기본 헤더 → 요청별 헤더 순서로 병합)
     const headers = new Headers(this.headers);
-    request.headers?.forEach(([key, value]) => {
-      headers.set(key, value);
-    });
+    if (request.headers) {
+      new Headers(request.headers).forEach((value, key) => {
+        headers.set(key, value);
+      });
+    }
     // Content-Type이 명시되지 않은 경우, body의 타입을 분석하여 자동으로 설정
     if (!headers.has("Content-Type")) {
       const guessed = this.guessMimeType(request.body);

--- a/src/types/HttpRequest.ts
+++ b/src/types/HttpRequest.ts
@@ -37,10 +37,14 @@ export interface HttpRequest extends HttpClientConfig {
   query?: Record<string, string | string[]>;
 
   /**
-   * 요청 헤더입니다. HttpClientConfig의 headers는 HeadersInit 타입이지만,
-   * HttpRequest에서는 Headers 객체로 변환되어 사용됩니다.
+   * 요청별 HTTP 헤더입니다.
+   * HttpClientConfig의 인스턴스 기본 헤더와 병합되며, 동일 키는 요청별 값이 우선합니다.
+   * fetch의 `headers` 옵션과 동일한 `HeadersInit` 형식을 그대로 받습니다.
+   *
+   * @example { 'X-API-Key': 'abc' }
+   * @example new Headers({ 'X-API-Key': 'abc' })
    */
-  headers?: Headers;
+  headers?: HeadersInit;
 
   /**
    * 요청 본문(body)에 포함될 데이터입니다.

--- a/tests/HttpClient.test.ts
+++ b/tests/HttpClient.test.ts
@@ -15,6 +15,13 @@ const server = setupServer(
     }
     return new MswHttpResponse(null, { status: 401, statusText: 'Unauthorized' });
   }),
+  http.get('https://api.test.com/echo-headers', ({ request }) => {
+    return MswHttpResponse.json({
+      apiKey: request.headers.get('X-API-Key'),
+      trace: request.headers.get('X-Trace-Id'),
+      contentType: request.headers.get('Content-Type'),
+    });
+  }),
 );
 
 beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
@@ -109,6 +116,46 @@ describe('HttpClient onRequest/onResponse hooks', () => {
 
     // /protected without auth header => 401
     await expect(client.get('/protected')).rejects.toThrow('Unauthorized - please login');
+  });
+
+  it('per-request headers accept a plain object (HeadersInit)', async () => {
+    const client = new HttpClient({ baseUrl: 'https://api.test.com' });
+
+    const res = await client.send({
+      method: 'GET',
+      path: '/echo-headers',
+      headers: { 'X-API-Key': 'abc-123', 'X-Trace-Id': 'trace-1' },
+    });
+    expect(res.ok).toBe(true);
+    const data = await res.json<{ apiKey: string; trace: string }>();
+    expect(data.apiKey).toBe('abc-123');
+    expect(data.trace).toBe('trace-1');
+  });
+
+  it('per-request headers accept a Headers instance', async () => {
+    const client = new HttpClient({ baseUrl: 'https://api.test.com' });
+
+    const headers = new Headers();
+    headers.set('X-API-Key', 'from-headers-class');
+    const res = await client.send({ method: 'GET', path: '/echo-headers', headers });
+    expect(res.ok).toBe(true);
+    const data = await res.json<{ apiKey: string }>();
+    expect(data.apiKey).toBe('from-headers-class');
+  });
+
+  it('per-request headers override instance default headers for the same key', async () => {
+    const client = new HttpClient({
+      baseUrl: 'https://api.test.com',
+      headers: { 'X-API-Key': 'instance-default' },
+    });
+
+    const res = await client.send({
+      method: 'GET',
+      path: '/echo-headers',
+      headers: { 'X-API-Key': 'request-override' },
+    });
+    const data = await res.json<{ apiKey: string }>();
+    expect(data.apiKey).toBe('request-override');
   });
 
   it('onRequest -> fetch -> onResponse execution order', async () => {


### PR DESCRIPTION
## Summary

While consuming `@iyulab/http-client@0.8.0` from another iyulab project, two related issues with per-request headers in `HttpClient.send()` surfaced:

### 1. Type narrowing breaks TS consumers (regression vs 0.7.x)

`HttpRequest extends HttpClientConfig`, but 0.8.0 narrowed `HttpRequest.headers` from `HeadersInit` to `Headers`:

\`\`\`ts
// HttpClientConfig.ts
headers?: HeadersInit;          // accepts {}, [['k','v']], Headers

// HttpRequest.ts (0.8.0)
headers?: Headers;              // ONLY Headers — incompatible with parent
\`\`\`

This breaks any existing code that does:

\`\`\`ts
client.send({ method: 'GET', path: '/foo', headers: { 'X-API-Key': key } });
//                                          ^^^^^^^ TS2740 in 0.8.0
\`\`\`

…even though the same shape is accepted at the instance level. The CHANGELOG flagged this as intentional, but the inconsistency makes the API surprising in practice.

### 2. Per-request header merge silently corrupts headers (real bug)

\`\`\`ts
// HttpClient.ts:111  (current)
request.headers?.forEach(([key, value]) => {
  headers.set(key, value);
});
\`\`\`

`Headers.prototype.forEach` has signature `(value, key, parent) => void`. The code destructures the first argument (`value: string`) as if it were an entries-tuple. Strings are iterable, so destructuring runs without throwing, but it produces wrong key/value pairs (e.g., \`Authorization: Bearer abc\` becomes something like \`B → e\`). The upload path (\`HttpClient.ts:226\`) already uses the correct \`(value, key) => ...\` pattern.

This wasn't caught because no test exercises \`send({ headers })\` directly — all existing header tests modify headers via the \`onRequest\` hook.

## Fix

- Revert `HttpRequest.headers` to `HeadersInit`, matching the parent type. Plain objects, `Headers` instances, and `[string, string][]` tuples are all accepted again.
- Rewrite the merge in `send()` to use \`new Headers(request.headers).forEach((value, key) => …)\`, mirroring the upload path.
- Add three regression tests against a new \`/echo-headers\` MSW endpoint:
  - plain-object headers
  - \`Headers\` instance headers
  - per-request override of instance defaults
- CHANGELOG entry under \`Unreleased\` documenting both items.

\`new Headers(init)\` already validates the input, so accepting \`HeadersInit\` doesn't sacrifice safety.

## Test plan

- [x] \`npx vitest run\` — 77/77 pass (was 74/74 before; 3 new tests added)
- [x] \`npm run build\` — clean, dist/index.d.ts shows \`HttpRequest.headers?: HeadersInit\`
- [x] Manually verified the fix unblocks the consumer code in iyulab/alldot (All.Manual frontend) where \`api.send({ ..., headers: { 'X-API-Key': apiKey } })\` previously errored on TS2740 against 0.8.0

## Discovered via

Dogfooding 0.8.0 from \`iyulab/alldot\` (All.Manual frontend, axios → http-client migration). The narrowing surfaced as a TS error in \`src/services/api.ts\` when consuming the published 0.8.0 type definitions; the merge bug was found while reading the surrounding code to plan the consumer-side migration.